### PR TITLE
add ability to set testIndicator

### DIFF
--- a/src/Model/Document.php
+++ b/src/Model/Document.php
@@ -44,9 +44,9 @@ class Document
      */
     private $trade;
 
-    public function __construct($type = self::TYPE_BASIC)
+    public function __construct($type = self::TYPE_BASIC, $testIndicator = false)
     {
-        $this->context = new DocumentContext($type);
+        $this->context = new DocumentContext($type, $testIndicator);
         $this->header = new Header();
         $this->trade = new Trade();
     }
@@ -91,6 +91,4 @@ class Document
     {
         $this->trade = $trade;
     }
-
-
 }

--- a/src/Model/DocumentContext.php
+++ b/src/Model/DocumentContext.php
@@ -26,7 +26,23 @@ class DocumentContext
     {
         $this->type = new ContextParameterID('urn:ferd:CrossIndustryDocument:invoice:1p0:' . strtolower($type));
         if ($testIndicator) {
-            $this->testIndicator = new Indicator($testIndicator);
+            $this->setTestIndicator($testIndicator);
         }
+    }
+
+    /**
+    * @return Indicator
+    */
+    public function getTestIndicator()
+    {
+        return $this->testIndicator;
+    }
+
+    /**
+     * @param bool $bool
+     */
+    public function setTestIndicator(bool $bool)
+    {
+        $this->testIndicator = new Indicator($bool);
     }
 }

--- a/src/Model/DocumentContext.php
+++ b/src/Model/DocumentContext.php
@@ -31,7 +31,7 @@ class DocumentContext
     }
 
     /**
-    * @return Indicator
+    * @return null|Indicator
     */
     public function getTestIndicator()
     {


### PR DESCRIPTION
Currently there is no way to set the testIndicator. 

This commits adds the ability to set the TestIndicator while instantiating
the DocumentContext or directly via public Methods.