### PR TITLE
Added doctrine/annotations to dependencies (#58)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
   ],
   "require": {
     "php": "^7.4 || ^8.0",
+    "doctrine/annotations": "^1.14 || ^2.0",
     "jms/serializer": "^3.16",
     "ext-dom": "*"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c9573174f6533c77ec3275d757d49e6",
+    "content-hash": "16ae8c2f7dfc590d056534d3b838d2bd",
     "packages": [
         {
             "name": "doctrine/annotations",


### PR DESCRIPTION
Version 3.30.0 of `jms/serializer` dropped `doctrine/annotations` from its dependencies, so it needs to be directly required.

This pull request fixes #58 via requiring `doctrine/annotations` explicitly.

An alternative would be to convert all annotations to attributes and bump the minimum php version to 8.0. If it is preferred I can make those changes instead.