### PR TITLE
Correct position for SpecifiedLegalOrganization in TradeParty

### DIFF
--- a/src/zugferd2/Model/TradeParty.php
+++ b/src/zugferd2/Model/TradeParty.php
@@ -10,7 +10,7 @@ use JMS\Serializer\Annotation\Type;
 use JMS\Serializer\Annotation\XmlElement;
 use JMS\Serializer\Annotation\XmlList;
 
-#[AccessorOrder(order: 'custom', custom: ['id', 'globalID', 'name', 'description', 'definedTradeContact', 'postalTradeAddress', 'uriUniversalCommunication', 'taxRegistrations'])]
+#[AccessorOrder(order: 'custom', custom: ['id', 'globalID', 'name', 'description', 'specifiedLegalOrganization', 'definedTradeContact', 'postalTradeAddress', 'uriUniversalCommunication', 'taxRegistrations'])]
 class TradeParty
 {
     #[Type(Id::class)]


### PR DESCRIPTION
The `SpecifiedLegalOrganization` element was generated in the wrong position when `\Easybill\ZUGFeRD2\Model\TradeParty::$specifiedLegalOrganization` is set.

This caused the generated extended profile xml to be invalid.