### PR TITLE
Add missing properties in TradeSettlementLineMonetarySummation

### DIFF
--- a/src/zugferd2/Model/TradeSettlementLineMonetarySummation.php
+++ b/src/zugferd2/Model/TradeSettlementLineMonetarySummation.php
@@ -17,6 +17,26 @@ class TradeSettlementLineMonetarySummation
 
     #[Type(Amount::class)]
     #[XmlElement(cdata: false, namespace: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100')]
+    #[SerializedName('ChargeTotalAmount')]
+    public ?Amount $chargeTotalAmount = null;
+
+    #[Type(Amount::class)]
+    #[XmlElement(cdata: false, namespace: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100')]
+    #[SerializedName('AllowanceTotalAmount')]
+    public ?Amount $allowanceTotalAmount = null;
+
+    #[Type(Amount::class)]
+    #[XmlElement(cdata: false, namespace: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100')]
+    #[SerializedName('TaxTotalAmount')]
+    public ?Amount $taxTotalAmount = null;
+
+    #[Type(Amount::class)]
+    #[XmlElement(cdata: false, namespace: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100')]
+    #[SerializedName('GrandTotalAmount')]
+    public ?Amount $grandTotalAmount = null;
+
+    #[Type(Amount::class)]
+    #[XmlElement(cdata: false, namespace: 'urn:un:unece:uncefact:data:standard:ReusableAggregateBusinessInformationEntity:100')]
     #[SerializedName('TotalAllowanceChargeAmount')]
     public ?Amount $totalAllowanceChargeAmount = null;
 


### PR DESCRIPTION
Add missing properties for TradeSettlementLineMonetarySummation which are used only in zugferd 2.3 extended profile.